### PR TITLE
add adjacent post link and tests

### DIFF
--- a/build/create-pages.js
+++ b/build/create-pages.js
@@ -64,14 +64,13 @@ function createPostListing(allPosts, POSTS_PER_PAGE, createPage) {
 
 function createPosts(allPosts, createPage) {
   allPosts
-    .forEach(({ fields }) => {
+    .forEach(({ fields: { slug }, frontmatter: { previous, next } }) => {
       const blogPostTemplate = path.resolve('./src/templates/blog-post/index.tsx');
+
       createPage({
-        path: fields.slug,
+        path: slug,
         component: blogPostTemplate,
-        context: {
-          slug: fields.slug,
-        },
+        context: { slug, previous, next },
       });
     });
 }
@@ -113,6 +112,8 @@ async function query(graphql) {
               frontmatter {
                 tags
                 category
+                next
+                previous
               }
             }
           }

--- a/e2e/blog-navigation.spec.js
+++ b/e2e/blog-navigation.spec.js
@@ -1,0 +1,17 @@
+/* eslint @typescript-eslint/no-var-requires: 0 */
+
+Feature('Blog Navigation');
+
+const adjacentPostLink = '//a[contains(@class, "adjacent-post")]';
+
+Scenario('Go to previous blog article', async (I) => {
+  await I.amOnPage('/abstracting-kitchen-quoter/');
+  await I.retry(3).click(locate(adjacentPostLink).first());
+  await I.seeInCurrentUrl('/quoting-kitchen-with-style/');
+});
+
+Scenario('Go to next blog article', async (I) => {
+  await I.amOnPage('/abstracting-kitchen-quoter/');
+  await I.retry(3).click(locate(adjacentPostLink).last());
+  await I.seeInCurrentUrl('/calculator-works/');
+});

--- a/e2e/site-navigation.spec.js
+++ b/e2e/site-navigation.spec.js
@@ -37,4 +37,3 @@ Scenario('Open tag listing page from blog posts page', async (I) => {
   await I.retry(3).click(locate(tags).first());
   await I.retry(3).see(tagName, 'h1');
 });
-

--- a/e2e/site-navigation.spec.js
+++ b/e2e/site-navigation.spec.js
@@ -37,3 +37,4 @@ Scenario('Open tag listing page from blog posts page', async (I) => {
   await I.retry(3).click(locate(tags).first());
   await I.retry(3).see(tagName, 'h1');
 });
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -6017,7 +6017,8 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -10087,7 +10088,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10105,11 +10107,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10122,15 +10126,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10233,7 +10240,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10243,6 +10251,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10255,17 +10264,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10282,6 +10294,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10354,7 +10367,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10364,6 +10378,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10439,7 +10454,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10469,6 +10485,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10486,6 +10503,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10524,11 +10542,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -14131,12 +14151,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "scheduler": {
           "version": "0.13.6",
@@ -14172,6 +14194,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -16755,7 +16778,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -16778,6 +16802,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/src/components/adjacent-post-link/index.test.tsx
+++ b/src/components/adjacent-post-link/index.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AdjacentPostLink } from './index';
+import { previous, next } from './mock';
+
+describe('AdjacentPostLink', () => {
+  describe('Previous Post label', () => {
+    it('should show label if previous is provided', () => {
+      const { queryByText } = render(<AdjacentPostLink previous={previous} next={null} />);
+      expect(queryByText(/Previous Post/)).not.toBeNull();
+    });
+    it('should not show label if previous is not provided', () => {
+      const { queryByText } = render(<AdjacentPostLink previous={null} next={null} />);
+      expect(queryByText(/Previous Post/)).toBeNull();
+    });
+    it('should show the name of the previous post', () => {
+      const { getByText } = render(<AdjacentPostLink previous={previous} next={null} />);
+      expect(getByText('Introducing the New React Concurrent Mode')).toBeDefined();
+    });
+  });
+  describe('Next Post Label', () => {
+    it('should show Next Post label if next  is provided', () => {
+      const { queryByText } = render(<AdjacentPostLink previous={null} next={next} />);
+      expect(queryByText(/Next Post/)).not.toBeNull();
+    });
+    it('should not show label if next is not provided', () => {
+      const { queryByText } = render(<AdjacentPostLink previous={null} next={null} />);
+      expect(queryByText(/Next Post/)).toBeNull();
+    });
+    it('should show the name of the next post', () => {
+      const { getByText } = render(<AdjacentPostLink previous={null} next={next} />);
+      expect(getByText('The Implications of React Concurrent Mode')).toBeDefined();
+    });
+  });
+});

--- a/src/components/adjacent-post-link/index.tsx
+++ b/src/components/adjacent-post-link/index.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { theme } from '../../utils/theme';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  @media ${theme.deviceSize.tablet}{
+    flex-direction: row;
+  }
+  
+  justify-content: space-around;
+  align-items: center;
+  padding: .5em;
+  background-color: #ddd;
+  border-radius: ${theme.borderRadius};
+  box-shadow: ${theme.lightBoxShadow};
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: #333;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: .5em;
+  &:hover {
+    color: ${theme.secondaryColor}
+  }
+`;
+
+export type TAdjacentPostLink = {
+  fields: {
+    slug: string;
+  };
+  frontmatter: {
+    title: string;
+  };
+};
+type TAdjacentPostLinkProps = {
+  previous: TAdjacentPostLink;
+  next: TAdjacentPostLink;
+}
+
+const LinkHeader = styled.div`
+  font-size: 0.6em;
+`;
+
+const PostTitle = styled.div`
+  font-weight: 600;
+  font-size: .9em;
+`;
+
+const StyledIcon = styled(FontAwesomeIcon)`
+  padding: 0 .25em;
+`;
+
+type TPostLinkProps = {side: 'left' | 'right'; title: string; slug: string};
+
+const PostLink: React.FC< TPostLinkProps> = ({ side, title, slug }) => (
+  <StyledLink to={slug}>
+    {side === 'left' && <StyledIcon icon={faChevronLeft} size="2x" />}
+    <div>
+      <LinkHeader>{side === 'left' ? 'Previous Post' : 'Next Post'}</LinkHeader>
+      <PostTitle>{title}</PostTitle>
+    </div>
+    {side === 'right' && <StyledIcon icon={faChevronRight} size="2x" />}
+  </StyledLink>
+);
+
+export const AdjacentPostLink: React.FC<TAdjacentPostLinkProps> = ({ previous, next }) => {
+  if (!previous && !next) return null;
+  return (
+    <Wrapper>
+      {
+        previous && <PostLink side="left" title={previous.frontmatter.title} slug={previous.fields.slug} />
+      }
+      {
+        next && <PostLink side="right" title={next.frontmatter.title} slug={next.fields.slug} />
+      }
+    </Wrapper>
+  );
+};

--- a/src/components/adjacent-post-link/mock.ts
+++ b/src/components/adjacent-post-link/mock.ts
@@ -1,0 +1,8 @@
+export const previous = {
+  fields: { slug: '/previous/' },
+  frontmatter: { title: 'Introducing the New React Concurrent Mode' },
+};
+export const next = {
+  fields: { slug: '/next/' },
+  frontmatter: { title: 'The Implications of React Concurrent Mode' },
+};

--- a/src/components/adjacent-post-link/stories.tsx
+++ b/src/components/adjacent-post-link/stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { AdjacentPostLink } from '.';
+import { next, previous } from './mock';
+
+storiesOf('AdjacentPostLink', module)
+  .add('default', () => (
+    <AdjacentPostLink next={next} previous={previous} />
+  ));

--- a/src/pages/posts/2019-02/quoting-kitchen-with-style/index.mdx
+++ b/src/pages/posts/2019-02/quoting-kitchen-with-style/index.mdx
@@ -5,7 +5,8 @@ dateModified: 2019-09-29
 draft: false
 projectSlug: /projects/kitchen-quoter/
 image: './kelly-sikkema-xoU52jUVUXA-unsplash.jpg'
-description: A desktop app that calculates a quotation for a high-end kitchen based on an user-specified algorithm and various input types. 
+description: A desktop app that calculates a quotation for a high-end kitchen based on an user-specified algorithm and various input types.
+next: /abstracting-kitchen-quoter/
 tags:     
     - Electron
     - Side Hustle
@@ -24,7 +25,9 @@ should accomplish a few key objectives:
 
 So far, I prototyped a single page desktop application as shown below. 
 
-<img style="width: 100%" src="/gifs/kitchen-quoter-2.gif" alt="Kitchen Quoter" />    
+<div class="ui container">
+    <img style="width: 100%" src="/gifs/kitchen-quoter-2.gif" alt="Kitchen Quoter" />
+</div> 
 <figcaption>Kitchen Quotation Tool built using Electron JS</figcaption>
 
 I built this using <a href="https://electronjs.org/" target="_blank" alt="ElectronJS">Electron</a>, a tool used for building cross-platform desktop apps with web syntax (HTML/CSS/JavaScript). For my project, I'm using React, Redux for state management, and Semantic UI React for a polished interface.  

--- a/src/pages/posts/2019-03/abstracting-kitchen-quoter/index.mdx
+++ b/src/pages/posts/2019-03/abstracting-kitchen-quoter/index.mdx
@@ -6,7 +6,9 @@ draft: false
 projectSlug: /projects/kitchen-quoter/
 category: Side Project
 image: './ibrahim-rifath-3HE4xVYlzO0-unsplash.jpg'
-description: The original kitchen quoter was specific to one business and use-case. I'm aiming to generalize that design, so it's reusable across different scenarios and businesses.    
+description: The original kitchen quoter was specific to one business and use-case. I'm aiming to generalize that design, so it's reusable across different scenarios and businesses.
+previous: /quoting-kitchen-with-style/
+next: /calculator-works/    
 tags:  
     - Side Hustle    
 ---
@@ -29,7 +31,7 @@ In an effort to make a successful side project with real tangible value, I decid
 My goal is allow any user, who needs to generate quotes interactively, to build their own calculators on the fly.
 Here's my progress so far...
 <div class="ui container">
-    <img class="ui image" src="/gifs/kitchen-quoter-3.gif" alt="Kitchen Quoter" />    
+    <img style="width: 100%" class="ui image" src="/gifs/kitchen-quoter-3.gif" alt="Kitchen Quoter" />    
 </div>
 
 ## BYOC - Build Your Own Calculator

--- a/src/pages/posts/2019-03/calculator-works/index.mdx
+++ b/src/pages/posts/2019-03/calculator-works/index.mdx
@@ -5,7 +5,8 @@ dateModified: 2019-09-29
 draft: false
 projectSlug: /projects/kitchen-quoter/
 image: './ashraf-ali-JLW-T4LiJCw-unsplash.jpg'
-description: Working version of an user-defined dynamic calculator for generating price quotation customizable to any business.    
+description: Working version of an user-defined dynamic calculator for generating price quotation customizable to any business.
+previous: /abstracting-kitchen-quoter/    
 tags:      
     - Electron
     - Side Hustle

--- a/src/templates/blog-post-listing/types.ts
+++ b/src/templates/blog-post-listing/types.ts
@@ -15,6 +15,8 @@ export type TFrontMatter = {
   dateCreated: string;
   dateModified: string;
   description: string;
+  previous?: string;
+  next?: string;
 };
 export type TPostNode = {
   id: string;

--- a/src/templates/blog-post/index.tsx
+++ b/src/templates/blog-post/index.tsx
@@ -16,8 +16,9 @@ import { PostNavigation } from './post-navigation';
 import { siteMetadata } from '../../../gatsby-config';
 import { ShareLinks } from './share-links';
 import { theme } from '../../utils/theme';
+import { AdjacentPostLink } from '../../components/adjacent-post-link';
 
-const BlogPost: React.FC<TProps> = (props) => {
+const BlogPost: React.FC<TProps> = ({ data: { post, previousPost, nextPost } }) => {
   const [showMobileToc, setShowMobileToc] = useState(false);
   const [isCSR, setIsCSR] = useState(false);
 
@@ -35,8 +36,6 @@ const BlogPost: React.FC<TProps> = (props) => {
 
   const toggleTableOfContentModal = (): void => setShowMobileToc(!showMobileToc);
 
-  const { data } = props;
-  const { post } = data;
   const postUrl = `${siteMetadata.canonicalUrl}${post.fields.slug}`;
   const disqusConfig = {
     url: `${postUrl}`,
@@ -72,6 +71,8 @@ const BlogPost: React.FC<TProps> = (props) => {
             <div className="js-toc-content">
               <MarkdownMdxProvider content={post.body} />
             </div>
+            <AdjacentPostLink previous={previousPost} next={nextPost} />
+            <br />
             <Disqus.DiscussionEmbed shortname={siteMetadata.title} config={disqusConfig} />
           </MainContent>
           <PostNavigation
@@ -109,30 +110,48 @@ const ShareLinksWrapper = styled.div`
 `;
 
 export const query = graphql`
-    query($slug: String!) {
-        post: mdx(fields: { slug: { eq: $slug }, contentType: { eq: "post" } } ) {
-            id
-            timeToRead
-            body
-            tableOfContents(
-                maxDepth: 4
-            )
-            fields {
-                slug
-            }
-            frontmatter {
-                title
-                tags
-                dateCreated(formatString: "DD MMM, YYYY")
-                dateModified(formatString: "DD MMM, YYYY")
-                category
-                description
-                image {
-                    publicURL
-                }
-            }
+  query($slug: String!, $previous: String, $next: String) {
+    post: mdx(fields: { slug: { eq: $slug }, contentType: { eq: "post" } } ) {
+      id
+      timeToRead
+      body
+      tableOfContents(
+        maxDepth: 4
+      )
+      fields {
+        slug
+      }
+      frontmatter {
+        title
+        tags
+        dateCreated(formatString: "DD MMM, YYYY")
+        dateModified(formatString: "DD MMM, YYYY")
+        category
+        description
+        image {
+          publicURL
         }
+        previous
+        next
+      }
     }
+    previousPost: mdx(fields: { slug: { eq: $previous } } ){
+      fields {
+        slug
+      }
+      frontmatter {
+        title
+      }
+    }
+    nextPost: mdx(fields: {slug: { eq: $next } } ){
+      fields {
+        slug
+      }
+      frontmatter {
+        title
+      }
+    }
+  }
 `;
 
 export default BlogPost;

--- a/src/templates/blog-post/types.ts
+++ b/src/templates/blog-post/types.ts
@@ -1,5 +1,6 @@
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { TFrontMatter } from '../blog-post-listing/types';
+import { TAdjacentPostLink } from '../../components/adjacent-post-link';
 
 type TItems = {
   title: string;
@@ -29,6 +30,8 @@ export type TProps = {
         tags: TTag[];
       };
     };
+    previousPost?: TAdjacentPostLink;
+    nextPost?: TAdjacentPostLink;
   };
 }
 


### PR DESCRIPTION
Adjacent post links added for navigation to related blogs from any blog post rather than have the user navigate to a blog from the post listing. This lets the user navigate a related set of blogs in a chronological order quicker. 